### PR TITLE
Update Rustwell CSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustwell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitflags 2.11.0",
  "krilla",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustwell"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags 2.11.0",
  "krilla",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "rustwell-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/crates/rustwell/Cargo.toml
+++ b/crates/rustwell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwell"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 description = "A library for parsing and compiling fountain screenplay scripts."

--- a/crates/rustwell/README.md
+++ b/crates/rustwell/README.md
@@ -10,7 +10,7 @@ Add this dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustwell = "0.3.0"
+rustwell = "0.3.1"
 ```
 
 and then start using the library. Please read the documentation for more details on how to use the library.

--- a/crates/rustwell/src/export/style.css
+++ b/crates/rustwell/src/export/style.css
@@ -1,15 +1,13 @@
 /* Reset */
-.rustwell div,
-.rustwell p,
-.rustwell span,
-.rustwell strong,
-.rustwell em {
+.rustwell,
+.rustwell * {
     margin: 0;
     padding: 0;
     border: 0;
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
+    box-sizing: content-box;
 }
 
 /* Wrapper */


### PR DESCRIPTION
There was an issue where some parts of the `css` Rustwell relied on could get reset when not in an isolated context. Specifically `box-sizing`.

Also updates patch version to be able to publish this for use in [Dionysus](https://github.com/frblo/dionysus).