### PR TITLE
Remove enforced styles

### DIFF
--- a/crates/rustwell/src/export/pdf.rs
+++ b/crates/rustwell/src/export/pdf.rs
@@ -454,7 +454,7 @@ impl PdfExporter {
                         }
                     }
                     Element::Lyrics(s) => {
-                        write_element!(s, &MARGINS.lyrics, Alignment::RightToLeft);
+                        write_element!(s, &MARGINS.lyrics, Alignment::LeftToRight);
                     }
                     Element::Transition(s) => {
                         write_element!(s, &MARGINS.transition, Alignment::RightToLeft);

--- a/crates/rustwell/src/export/style.css
+++ b/crates/rustwell/src/export/style.css
@@ -61,13 +61,11 @@
 
 .rustwell .title-page .title p {
     font-size: 1.5em;
-    text-transform: uppercase;
     font-weight: bold;
     margin-bottom: 0.5em;
 }
 
 .rustwell .title-page .credit p {
-    font-style: italic;
     margin-bottom: 1em;
 }
 
@@ -76,7 +74,6 @@
 }
 
 .rustwell .title-page .source p {
-    font-style: italic;
     margin-bottom: 1em;
 }
 
@@ -100,8 +97,6 @@
 .rustwell div.scene-heading {
     width: 38.3em;
     margin-top: 2em;
-    text-transform: uppercase;
-    font-weight: bold;
 }
 
 .rustwell div.block {
@@ -180,7 +175,6 @@
 .rustwell .lyrics p {
     padding-left: 6.4em;
     width: 25.6em;
-    text-transform: uppercase;
 }
 
 /* Synopsis */


### PR DESCRIPTION
Fixes a bug lyric elements were aligned right-to-left in the `pdf` output, which it should not be. Also removes enforced styles (like UPPERCASE, _italics_, etc.) on elements in the `html` export.